### PR TITLE
put "pragma once" on line 1

### DIFF
--- a/.verify-helper/timestamps.remote.json
+++ b/.verify-helper/timestamps.remote.json
@@ -1,6 +1,6 @@
 {
-"test/yosupo-convolution-mod-1000000007.test.cpp": "2023-04-26 17:13:30 +0900",
-"test/yosupo-convolution-mod.test.cpp": "2023-04-26 16:38:27 +0900",
+"test/yosupo-convolution-mod-1000000007.test.cpp": "2023-04-26 23:09:33 +0900",
+"test/yosupo-convolution-mod.test.cpp": "2023-04-26 23:09:33 +0900",
 "test/yosupo-shortest-path.test.cpp": "2023-04-25 02:28:47 +0000",
 "test/yosupo-shortest-path.test.py": "1970-01-01 00:00:00 +0000"
 }

--- a/cpp/modint.hpp
+++ b/cpp/modint.hpp
@@ -1,9 +1,9 @@
+#pragma once
+
 /**
  * @file modint.hpp
  * @brief 四則演算において自動で mod を取るクラス
  */
-
-#pragma once
 
 #include <iostream>
 #include <utility>


### PR DESCRIPTION
`#pragma once` が1行目にないとoj-bundleが失敗するようだったのでdoxygenと入れ替えました。
doxygenが2行目以降に来てもドキュメントのインデックスが正しく生えることを確認しました。